### PR TITLE
VS Code: remove obsolete workarounds

### DIFF
--- a/.shims/.editorconfig
+++ b/.shims/.editorconfig
@@ -1,9 +1,0 @@
-# https://editorconfig.org
-
-root = false
-
-[*]
-end_of_line = lf
-
-[*.bat]
-end_of_line = crlf

--- a/.shims/pylint
+++ b/.shims/pylint
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-exec poetry run python -m "${0##*/}" "$@"

--- a/.shims/pylint.bat
+++ b/.shims/pylint.bat
@@ -1,1 +1,0 @@
-@poetry run python -m pylint %*

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,13 +27,11 @@
     "**/*.egg-info": true,
     "**/__pycache__": true
   },
-  "python.defaultInterpreterPath": "${workspaceFolder}/.venv/",
   "python.linting.pylintArgs": [
     "--enable-all-extensions"
   ],
   "python.linting.pylintCategorySeverity.refactor": "Warning",
   "python.linting.pylintEnabled": true,
-  "python.linting.pylintPath": "${workspaceFolder}/.shims/pylint",
   "python.testing.pytestArgs": [
     "tests"
   ],


### PR DESCRIPTION
Remove workarounds which no longer work with current versions of
VS Code’s Python extension (starting with version 2022.18.1).

From that version on, those workarounds are no longer necessary
anyway. The Python extension now appears to detect the venv’s
interpreter automatically and then switch to it.
