### PR TITLE
VS Code: re-add `pylintPath`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -32,6 +32,7 @@
   ],
   "python.linting.pylintCategorySeverity.refactor": "Warning",
   "python.linting.pylintEnabled": true,
+  "python.linting.pylintPath": "pylint",
   "python.testing.pytestArgs": [
     "tests"
   ],


### PR DESCRIPTION
Fix a regression introduced in the previous commit.

Turns out we do need a `pylintPath` setting, though it’s sufficient
to give it a value of `pylint`.

Failing to have that setting causes VS Code to give precedence to
a system-wide pylint, which wouldn’t see packages from the venv,
causing false positives in the editor.
