### PR TITLE
Add GitHub CI workflow

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -29,3 +29,6 @@ trim_trailing_whitespace = false
 
 [*.py]
 indent_size = 4
+
+[*.yml]
+indent_size = 2

--- a/.gitattributes
+++ b/.gitattributes
@@ -28,3 +28,4 @@
 *.py            text eol=lf
 *.toml          text eol=lf
 *.txt           text eol=lf
+*.yml           text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: Run CI
 
 on: [push]
 
+env:
+  CI_POETRY_VERSION: '1.6.1'
+
 jobs:
   build:
     runs-on: ubuntu-22.04
@@ -10,9 +13,23 @@ jobs:
       - name: Check out source tree
         uses: actions/checkout@v3
 
+      - name: Load cached Poetry installation
+        id: load-cached-poetry
+        uses: actions/cache@v3
+        with:
+          path: ~/.local
+          key: poetry-release-v${{ env.CI_POETRY_VERSION }}
+
+      - name: Update PATH
+        if: steps.load-cached-poetry.outputs.cache-hit == 'true'
+        run: |-
+          echo ~/.local/bin >> ${GITHUB_PATH}
+
       - name: Install Poetry
         uses: snok/install-poetry@v1
+        if: steps.load-cached-poetry.outputs.cache-hit != 'true'
         with:
+          version: ${{ env.CI_POETRY_VERSION }}
           virtualenvs-create: true
           virtualenvs-in-project: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
       - name: Use specified Python version
         uses: actions/setup-python@v4
         with:
+          cache: poetry
           python-version-file: .python-version
 
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: Run CI
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Check out source tree
+        uses: actions/checkout@v3
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+
+      - name: Use specified Python version
+        uses: actions/setup-python@v4
+        with:
+          python-version-file: .python-version
+
+      - name: Install dependencies
+        # See also:
+        # https://github.com/python-poetry/poetry/issues/7184
+        run: poetry install --no-ansi --no-interaction --no-root
+
+      - name: Install target package
+        run: poetry install --no-ansi --no-interaction
+
+      - name: Run static typechecking
+        run: poetry run poe typecheck
+
+      - name: Run linter
+        run: poetry run poe linter
+
+      - name: Run unit tests
+        run: poetry run poe tests

--- a/README.md
+++ b/README.md
@@ -167,6 +167,17 @@ To execute the static type check, run:
 poetry run poe typecheck
 ```
 
+### Running the entire CI pipeline locally
+
+If you have [act](https://github.com/nektos/act) installed, run:
+
+```sh
+act --container-options "-v act-toolcache:/opt/hostedtoolcache"
+```
+
+See also
+issue [nektos/act#1987](https://github.com/nektos/act/issues/1987).
+
 ### Generating project documentation
 
 To generate project documentation and open it in your browser, run:


### PR DESCRIPTION
- Bump dependencies
- Fix linting issues in tests
- List products in usage message
- Accept empty `releasedate` in source
- Update lockfile with latest dependencies
- Bump urllib3 from 2.0.4 to 2.0.6
- Add GitHub CI workflow
- Use hosted tool cache for venv, Python
- Use hosted tool cache for Poetry
