### PR TITLE
Prevent possible code injection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,9 @@ jobs:
         run: poetry version --no-ansi --no-interaction
 
       - name: Bump package version
-        run: poetry version --no-ansi --no-interaction "${{ inputs.target_version }}"
+        env:
+          TARGET_VERSION: ${{ inputs.target_version }}
+        run: poetry version --no-ansi --no-interaction "${TARGET_VERSION}"
 
       - name: Gather bumped package version
         run: |


### PR DESCRIPTION
Interpolating GitHub templating into shell scripts poses the risk of inadvertently injecting user-provided content.

Although the content is not really untrusted in this example (because users must have write access already before they trigger this workflow), it’s still good practice to make this safe in case the security boundary ever changes, or if someone copies and pastes this.

See also:

- [Keeping your GitHub Actions and workflows secure Part 2: Untrusted input](https://securitylab.github.com/research/github-actions-untrusted-input/)
