### PR TITLE
CI: pin API version, specify response format, fix hash

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,9 +65,13 @@ jobs:
           BASE_SHA="$(git rev-parse --symbolic-full-name @)"
           OBJECT_SHA=$(git rev-parse "${VERSION_BUMP_BRANCH}:${FILE_TO_COMMIT}")
           gh api --method POST '/repos/:owner/:repo/git/refs' \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
             --field ref="refs/heads/${VERSION_BUMP_BRANCH}"
             --field sha="${BASE_SHA}"
           gh api --method PUT "/repos/:owner/:repo/contents/${FILE_TO_COMMIT}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
             --field message="${MESSAGE}" \
             --field content=@<(base64 -i "${FILE_TO_COMMIT}") \
             --field branch="${VERSION_BUMP_BRANCH}" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
           VERSION_BUMP_BRANCH: version-bump/${{ env.NEW_VERSION }}
         run: |
           MESSAGE="Bump version to ${NEW_VERSION}"
-          BASE_SHA="$(git rev-parse --symbolic-full-name @)"
+          BASE_SHA="$(git rev-parse @)"
           OBJECT_SHA=$(git rev-parse "${VERSION_BUMP_BRANCH}:${FILE_TO_COMMIT}")
           gh api --method POST '/repos/:owner/:repo/git/refs' \
             -H "Accept: application/vnd.github+json" \


### PR DESCRIPTION
- CI: specify API version, response format
- CI: use actual hash, not symbolic ref
