### PR TITLE
CI: remove `act` workaround, which is now obsolete

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ If you have [act](https://github.com/nektos/act) installed and a
 Docker daemon active, run:
 
 ```sh
-poetry run poe act
+act
 ```
 
 If that command fails with an error message like:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,9 +34,6 @@ verbosity = -1
 [tool.poe.tasks]
 tasks.cmd = "poe -v"
 tasks.help = "List available tasks"
-# See also issue [nektos/act#1987](https://github.com/nektos/act/issues/1987)
-act.cmd = "act --container-options '-v act-toolcache:/opt/hostedtoolcache'"
-act.help = "Run CI locally (requires active Docker daemon)"
 doc.cmd = "pdoc release_feed_mediola !release_feed_mediola.settings"
 doc.help = "Browse documentation"
 feed.script = "release_feed_mediola.cli:run"


### PR DESCRIPTION
With the release of act v0.2.58, the workaround for /opt/hostedtoolcache
is no longer necessary.

Remove custom `poe` task and update documentation.
