### PR TITLE
Simplify unit file by using systemd’s new %D specifier

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -48,5 +48,5 @@
   "python.testing.pytestEnabled": true,
   "workbench.editor.decorations.badges": false,
   "workbench.editor.decorations.colors": false,
-  "workbench.editor.untitled.hint": "hidden"
+  "workbench.editor.empty.hint": "hidden"
 }

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ To see a list of supported Mediola products, run
 
 You may want to run `release-feed-mediola` periodically to generate
 and update a feed file using a systemd timer and service.
-This requires Linux.
+This requires a Linux system and systemd version 256 or newer.
 
 ### Installing the unit files
 

--- a/contrib/systemd/release-feed-mediola@.service
+++ b/contrib/systemd/release-feed-mediola@.service
@@ -10,7 +10,7 @@ Wants=network-online.target
 ExecStart=/bin/bash -eux -o pipefail -c ' \
     incoming="$$(/bin/mktemp --suffix=.%p)"; \
     /usr/bin/%p "$${1}" | tee "$${incoming}"; \
-    DATA_DIR="$${XDG_DATA_HOME:-%h/.local/share}/feeds/%p/$${1}"; \
+    DATA_DIR="%D/feeds/%p/$${1}"; \
     mkdir -p "$${DATA_DIR}";\
     /bin/cp -f --no-preserve=mode \
         "$${incoming}" \


### PR DESCRIPTION
- **VS Code: migrate settings**
- **Unit file: use new %D specifier**
